### PR TITLE
Error on missing informations in reports (Name,Port,Host)

### DIFF
--- a/nerve/report.go
+++ b/nerve/report.go
@@ -55,6 +55,9 @@ func (r *Report) UnmarshalJSON(b []byte) error {
 	if err := json.Unmarshal(b, &rr); err != nil {
 		return err
 	}
+	if rr.Port == 0 || rr.Host == "" || rr.Name == "" {
+		return errs.WithF(data.Fields{"report": rr}, "Missing Port or Host or Name in report.")
+	}
 	if rr.Available != nil && *rr.Available == false {
 		w := uint8(0)
 		rr.Weight = &w

--- a/nerve/reporter_console_test.go
+++ b/nerve/reporter_console_test.go
@@ -9,9 +9,6 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-var btrue = true
-var bfalse = false
-
 func TestReportConsole(t *testing.T) {
 	RegisterTestingT(t)
 	var b bytes.Buffer
@@ -19,8 +16,8 @@ func TestReportConsole(t *testing.T) {
 	write := bufio.NewWriter(&b)
 	reporter.writer = write
 
-	reporter.Report(Report{Available: &btrue})
-	reporter.Report(Report{Available: &bfalse})
+	reporter.Report(reportAvailable)
+	reporter.Report(reportNotAvailable)
 
 	write.Flush()
 

--- a/nerve/reporter_file_test.go
+++ b/nerve/reporter_file_test.go
@@ -10,6 +10,23 @@ import (
 )
 
 var s = &Service{}
+var btrue = true
+var bfalse = false
+var reportAvailable = Report{
+	Available: &btrue,
+	Host:      "127.0.0.1",
+	Port:      80,
+	Name:      "reportAvailable",
+}
+var reportNotAvailable = Report{
+	Available: &bfalse,
+	Host:      "127.0.0.1",
+	Port:      80,
+	Name:      "reportNotAvailable",
+}
+var reportMissingOptions = Report{
+	Available: &btrue,
+}
 
 func TestCannotInitOnWrongPath(t *testing.T) {
 	RegisterTestingT(t)
@@ -24,11 +41,23 @@ func TestCanReport(t *testing.T) {
 	reporter := NewReporterFile()
 	Expect(reporter.Init(s)).ToNot(HaveOccurred())
 
-	reporter.Report(Report{Available: &btrue})
+	reporter.Report(reportAvailable)
 
 	res, _ := ioutil.ReadFile(reporter.Path)
 	r, _ := NewReport(res)
 	Expect(*r.Available).Should(BeTrue())
+}
+
+func TestShouldErrWhenMissingOptionsReport(t *testing.T) {
+	RegisterTestingT(t)
+	reporter := NewReporterFile()
+	Expect(reporter.Init(s)).ToNot(HaveOccurred())
+
+	reporter.Report(reportMissingOptions)
+
+	res, _ := ioutil.ReadFile(reporter.Path)
+	_, err := NewReport(res)
+	Expect(err).ShouldNot(BeNil())
 }
 
 func TestReportReplace(t *testing.T) {
@@ -36,12 +65,12 @@ func TestReportReplace(t *testing.T) {
 	reporter := NewReporterFile()
 	Expect(reporter.Init(s)).ToNot(HaveOccurred())
 
-	reporter.Report(Report{Available: &btrue})
+	reporter.Report(reportAvailable)
 	res, _ := ioutil.ReadFile(reporter.Path)
 	r, _ := NewReport(res)
 	Expect(*r.Available).Should(BeTrue())
 
-	reporter.Report(Report{Available: &bfalse})
+	reporter.Report(reportNotAvailable)
 	res, _ = ioutil.ReadFile(reporter.Path)
 	Expect(res).Should(HaveLen(0))
 }
@@ -53,8 +82,8 @@ func TestReportAppend(t *testing.T) {
 	reporter.Append = true
 	Expect(reporter.Init(s)).ToNot(HaveOccurred())
 
-	reporter.Report(Report{Available: &btrue})
-	reporter.Report(Report{Available: &bfalse})
+	reporter.Report(reportAvailable)
+	reporter.Report(reportNotAvailable)
 
 	res, _ := ioutil.ReadFile(reporter.Path)
 	lines := strings.Split(string(res), "\n")


### PR DESCRIPTION
When the body of the report is not properly formated , we should fail fast.
Thus going from synapse to the original nerve lib.